### PR TITLE
Fix corner cases in developer categories

### DIFF
--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -216,6 +216,70 @@ class TestGitEventsAnalyzer(unittest.TestCase):
         categories = self.analyzer.get_developer_categories()
         self.assertDictEqual(categories, {"core": 2, "regular": 1, "casual": 1})
 
+    def test_get_categories_one_developer(self):
+        """Test if the categories are calculated correctly when there is only one developer"""
+
+        categories = self.analyzer.get_developer_categories()
+        self.assertDictEqual(categories, {"core": 0, "regular": 0, "casual": 0})
+
+        # Add a core developer with 100% of the contributions
+        extra_events = [
+            {
+                "type": "org.grimoirelab.events.git.commit",
+                "data": {"Author": "Author 1 <author1@example_new.com>", "message": "Another commit"},
+            },
+            {
+                "type": "org.grimoirelab.events.git.commit",
+                "data": {"Author": "Author 1 <author1@example_new.com>", "message": "Another commit"},
+            },
+            {
+                "type": "org.grimoirelab.events.git.commit",
+                "data": {"Author": "Author 1 <author1@example_new.com>", "message": "Another commit"},
+            },
+            {
+                "type": "org.grimoirelab.events.git.commit",
+                "data": {"Author": "Author 1 <author1@example_new.com>", "message": "Another commit"},
+            },
+        ]
+
+        self.analyzer.process_events(extra_events)
+        categories = self.analyzer.get_developer_categories()
+        self.assertDictEqual(categories, {"core": 1, "regular": 0, "casual": 0})
+
+    def test_get_developer_categories_tied(self):
+        """Test if the categories are calculated correctly when the core developers have the same contributions"""
+
+        categories = self.analyzer.get_developer_categories()
+        self.assertDictEqual(categories, {"core": 0, "regular": 0, "casual": 0})
+
+        # Add core developers with the same number of contributions
+        extra_events = [
+            {
+                "type": "org.grimoirelab.events.git.commit",
+                "data": {"Author": "Author 1 <author1@example_new.com>", "message": "Another commit"},
+            },
+            {
+                "type": "org.grimoirelab.events.git.commit",
+                "data": {"Author": "Author 2 <author2@example_new.com>", "message": "Another commit"},
+            },
+            {
+                "type": "org.grimoirelab.events.git.commit",
+                "data": {"Author": "Author 3 <author3@example_new.com>", "message": "Another commit"},
+            },
+            {
+                "type": "org.grimoirelab.events.git.commit",
+                "data": {"Author": "Author 4 <author4@example_new.com>", "message": "Another commit"},
+            },
+            {
+                "type": "org.grimoirelab.events.git.commit",
+                "data": {"Author": "Author 5 <author5@example_new.com>", "message": "Another commit"},
+            },
+        ]
+
+        self.analyzer.process_events(extra_events)
+        categories = self.analyzer.get_developer_categories()
+        self.assertDictEqual(categories, {"core": 4, "regular": 1, "casual": 0})
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/trustable_cli/metrics.py
+++ b/trustable_cli/metrics.py
@@ -176,13 +176,15 @@ class GitEventsAnalyzer:
         regular_threshold = int(0.8 * self.total_commits)
         casual_threshold = int(0.95 * self.total_commits)
         acc_commits = 0
+        last_core_contribution = 0
 
         for _, contributions in self.contributors.most_common():
             acc_commits += contributions
 
-            if acc_commits <= regular_threshold:
+            if acc_commits <= regular_threshold or contributions > last_core_contribution:
+                last_core_contribution = contributions
                 core += 1
-            elif acc_commits <= casual_threshold:
+            elif acc_commits <= casual_threshold or contributions == last_core_contribution:
                 regular += 1
             else:
                 casual += 1


### PR DESCRIPTION
This PR fixes some corner cases of developer categories in small repositories. If there is only one developer or if the core developers are tied in number of contributions, they are classified as core.