### PR TITLE
The request is not retried after the token is refreshed

### DIFF
--- a/grimoirelab_metrics/cli.py
+++ b/grimoirelab_metrics/cli.py
@@ -357,8 +357,8 @@ def schedule_repository(grimoirelab_client: GrimoireLabClient, uri: str, datasou
         "datasource_type": datasource,
         "datasource_category": category,
     }
-    res = grimoirelab_client.post("datasources/add_repository", json=data)
     try:
+        res = grimoirelab_client.post("datasources/add_repository", json=data)
         res.raise_for_status()
     except requests.HTTPError as e:
         if res.status_code == 405 and "already exists" in res.json()["error"]:

--- a/grimoirelab_metrics/grimoirelab_client.py
+++ b/grimoirelab_metrics/grimoirelab_client.py
@@ -108,7 +108,11 @@ class GrimoireLabClient:
             except requests.HTTPError as e:
                 if e.response.status_code == 403 and self._refresh_token:
                     self._refresh_auth_token()
-                return e.response
+                elif e.response.status_code == 405:
+                    # This case is when the repository already exists
+                    return e.response
+                else:
+                    last_exception = e
             except (requests.ConnectionError, requests.Timeout) as e:
                 self._reconnect()
                 last_exception = e


### PR DESCRIPTION
This PR updates the GrimoireLab client to fix a bug where the request doesn't retry with the new token after the previous one has expired.