### PR TITLE
Add OpenSearch timeout option to CLI

### DIFF
--- a/grimoirelab_metrics/cli.py
+++ b/grimoirelab_metrics/cli.py
@@ -66,6 +66,7 @@ DEFAULT_ELEPHANT_THRESHOLD = 0.5
 @click.option("--opensearch-user", type=str, help="OpenSearch user", default=None)
 @click.option("--opensearch-password", type=str, help="OpenSearch password", default=None)
 @click.option("--opensearch-ca-certs", type=str, help="OpenSearch CA certificate path (.pem file)", default=None)
+@click.option("--opensearch-timeout", type=int, help="OpenSearch timeout in seconds", default=30)
 @click.option("--output", help="File where the scores will be written", type=click.File("w"), default=sys.stdout)
 @click.option(
     "--repository-timeout",
@@ -110,6 +111,7 @@ def grimoirelab_metrics(
     opensearch_user: str | None = None,
     opensearch_password: str | None = None,
     opensearch_ca_certs: str | None = None,
+    opensearch_timeout: int = 30,
     output: typing.TextIO = sys.stdout,
     repository_timeout: int = 3600,
     from_date: datetime.datetime | None = None,
@@ -160,6 +162,7 @@ def grimoirelab_metrics(
             opensearch_user=opensearch_user,
             opensearch_password=opensearch_password,
             opensearch_ca_certs=opensearch_ca_certs,
+            opensearch_timeout=opensearch_timeout,
             from_date=from_date,
             to_date=to_date,
             verify_certs=verify_certs,
@@ -258,6 +261,7 @@ def generate_metrics_when_ready(
     opensearch_user: str | None = None,
     opensearch_password: str | None = None,
     opensearch_ca_certs: str | None = None,
+    opensearch_timeout: int = 30,
     from_date: datetime.datetime | None = None,
     to_date: datetime.datetime | None = None,
     verify_certs: bool = False,
@@ -277,6 +281,7 @@ def generate_metrics_when_ready(
     :param opensearch_user: OpenSearch user.
     :param opensearch_password: OpenSearch password.
     :param opensearch_ca_certs: OpenSearch CA certificate.
+    :param opensearch_timeout: OpenSearch timeout.
     :param from_date: Start date for metrics.
     :param to_date: End date for metrics.
     :param verify_certs: Verify SSL/TLS certificates.
@@ -306,6 +311,7 @@ def generate_metrics_when_ready(
                     opensearch_user=opensearch_user,
                     opensearch_password=opensearch_password,
                     opensearch_ca_certs=opensearch_ca_certs,
+                    opensearch_timeout=opensearch_timeout,
                     from_date=from_date,
                     to_date=to_date,
                     verify_certs=verify_certs,

--- a/grimoirelab_metrics/metrics.py
+++ b/grimoirelab_metrics/metrics.py
@@ -538,6 +538,7 @@ def get_repository_metrics(
     opensearch_user: str = None,
     opensearch_password: str = None,
     opensearch_ca_certs: str = None,
+    opensearch_timeout: int = 30,
     from_date: datetime.datetime = None,
     to_date: datetime.datetime = None,
     verify_certs: bool = True,
@@ -556,6 +557,7 @@ def get_repository_metrics(
     :param opensearch_user: Username to connect to OpenSearch, by default None
     :param opensearch_password: Password to connect to OpenSearch, by default None
     :param opensearch_ca_certs: Path to the CA certificate, by default None
+    :param opensearch_timeout: Timeout for the OpenSearch connection, by default 30
     :param verify_certs: Boolean, verify SSL/TLS certificates, default True
     :param from_date: Start date, by default None
     :param to_date: End date, by default None
@@ -571,6 +573,7 @@ def get_repository_metrics(
         password=opensearch_password,
         ca_certs_path=opensearch_ca_certs,
         verify_certs=verify_certs,
+        timeout=opensearch_timeout,
     )
 
     analyzer = GitEventsAnalyzer(
@@ -695,6 +698,7 @@ def connect_to_opensearch(
     ca_certs_path: str | None = None,
     verify_certs: bool = True,
     max_retries: int = 3,
+    timeout: int = 30,
 ) -> OpenSearch:
     """
     Connect to an OpenSearch instance using the given parameters.
@@ -705,6 +709,7 @@ def connect_to_opensearch(
     :param ca_certs_path: Path to the CA certificate
     :param verify_certs: Boolean, verify SSL/TLS certificates
     :param max_retries: Maximum number of retries in case of timeout
+    :param timeout: Timeout for each request in seconds
 
     :return: OpenSearch connection
     """
@@ -722,6 +727,7 @@ def connect_to_opensearch(
         ca_certs=ca_certs_path,
         max_retries=max_retries,
         retry_on_timeout=True,
+        timeout=timeout,
     )
 
     return os_conn


### PR DESCRIPTION
This PR introduces a option for OpenSearch timeout, allowing users to specify the timeout duration in seconds. The default value is set to 30 seconds.